### PR TITLE
Add vibe picker app with widget

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,10 @@
+# Xcode
+*.xcworkspace
+*.xcodeproj
+DerivedData/
+
+# Swift Package Manager
+.build/
+
+# Misc
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -1,2 +1,15 @@
-# widget-ios-trial
-trying out a widget
+# Pick Your Vibe
+
+This repo contains a tiny SwiftUI demo app and WidgetKit extension. The app lets you choose a daily "vibe" and the widget shows your latest pick.
+
+## Features
+
+- Four vibe choices: 🧠 Focus, 💪 Power, 😴 Chill and 😂 Joy
+- Vibe history is shared between the app and the widget using App Groups
+- The widget displays your current vibe and how many vibes you've picked in the last week
+- Every seventh pick triggers a small celebration
+- Tapping the widget opens the app
+
+## Building
+
+Open the project folder in Xcode and run the `VibeApp` target on an iOS 14+ device or simulator. The widget is included in the same workspace and can be added to the home screen after running the app once.

--- a/Shared/VibeData.swift
+++ b/Shared/VibeData.swift
@@ -1,0 +1,67 @@
+import Foundation
+import SwiftUI
+
+struct Vibe: Identifiable, Codable {
+    let id: String
+    let emoji: String
+    let name: String
+}
+
+final class VibeStore: ObservableObject {
+    static let shared = VibeStore()
+    private init() {
+        load()
+    }
+
+    private let appGroup = "group.com.example.vibe"
+    private let vibeKey = "selectedVibe"
+    private let historyKey = "vibeHistory"
+
+    @Published var selectedVibe: Vibe?
+    @Published var history: [Date] = []
+
+    func select(vibe: Vibe) {
+        selectedVibe = vibe
+        history.append(Date())
+        save()
+    }
+
+    func vibesThisWeek() -> Int {
+        let calendar = Calendar.current
+        let oneWeekAgo = calendar.date(byAdding: .day, value: -7, to: Date())!
+        return history.filter { $0 >= oneWeekAgo }.count
+    }
+
+    private func container() -> UserDefaults? {
+        UserDefaults(suiteName: appGroup)
+    }
+
+    private func save() {
+        guard let defaults = container() else { return }
+        if let vibe = selectedVibe {
+            defaults.set(try? JSONEncoder().encode(vibe), forKey: vibeKey)
+        }
+        defaults.set(try? JSONEncoder().encode(history), forKey: historyKey)
+    }
+
+    private func load() {
+        guard let defaults = container() else { return }
+        if let data = defaults.data(forKey: vibeKey),
+           let vibe = try? JSONDecoder().decode(Vibe.self, from: data) {
+            selectedVibe = vibe
+        }
+        if let histData = defaults.data(forKey: historyKey),
+           let hist = try? JSONDecoder().decode([Date].self, from: histData) {
+            history = hist
+        }
+    }
+}
+
+extension Vibe {
+    static let samples: [Vibe] = [
+        Vibe(id: "focus", emoji: "🧠", name: "Focus"),
+        Vibe(id: "power", emoji: "💪", name: "Power"),
+        Vibe(id: "chill", emoji: "😴", name: "Chill"),
+        Vibe(id: "joy", emoji: "😂", name: "Joy")
+    ]
+}

--- a/VibeApp/ContentView.swift
+++ b/VibeApp/ContentView.swift
@@ -1,0 +1,52 @@
+import SwiftUI
+
+struct ContentView: View {
+    @EnvironmentObject var store: VibeStore
+    @State private var showCelebration = false
+    @State private var animateID: String?
+
+    var body: some View {
+        NavigationView {
+            VStack(spacing: 20) {
+                Text(store.selectedVibe != nil ? "Your vibe today: \(store.selectedVibe!.emoji) \(store.selectedVibe!.name)!" : "Pick your vibe!")
+                    .font(.headline)
+                    .padding()
+                HStack(spacing: 15) {
+                    ForEach(Vibe.samples) { vibe in
+                        Button(action: {
+                            withAnimation(.spring(response: 0.3, dampingFraction: 0.5)) {
+                                animateID = vibe.id
+                                store.select(vibe: vibe)
+                                if store.vibesThisWeek() % 7 == 0 {
+                                    showCelebration = true
+                                }
+                            }
+                            DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
+                                animateID = nil
+                            }
+                        }) {
+                            Text(vibe.emoji)
+                                .font(.system(size: 40))
+                                .padding()
+                                .background(Color(.systemGray6))
+                                .clipShape(Circle())
+                                .scaleEffect(animateID == vibe.id ? 1.2 : 1.0)
+                        }
+                    }
+                }
+                Text("You've picked \(store.vibesThisWeek()) vibes this week.")
+                    .padding()
+            }
+            .navigationTitle("Pick Your Vibe")
+        }
+        .alert(isPresented: $showCelebration) {
+            Alert(title: Text("🎉 Keep it up!"))
+        }
+    }
+}
+
+struct ContentView_Previews: PreviewProvider {
+    static var previews: some View {
+        ContentView().environmentObject(VibeStore.shared)
+    }
+}

--- a/VibeApp/VibeApp.swift
+++ b/VibeApp/VibeApp.swift
@@ -1,0 +1,12 @@
+import SwiftUI
+
+@main
+struct VibeApp: App {
+    @StateObject private var store = VibeStore.shared
+    var body: some Scene {
+        WindowGroup {
+            ContentView()
+                .environmentObject(store)
+        }
+    }
+}

--- a/VibeWidget/VibeWidget.swift
+++ b/VibeWidget/VibeWidget.swift
@@ -1,0 +1,59 @@
+import WidgetKit
+import SwiftUI
+
+struct VibeEntry: TimelineEntry {
+    let date: Date
+    let vibe: Vibe?
+    let vibeCount: Int
+}
+
+struct Provider: TimelineProvider {
+    func placeholder(in context: Context) -> VibeEntry {
+        VibeEntry(date: Date(), vibe: nil, vibeCount: 0)
+    }
+
+    func getSnapshot(in context: Context, completion: @escaping (VibeEntry) -> ()) {
+        let store = VibeStore.shared
+        completion(VibeEntry(date: Date(), vibe: store.selectedVibe, vibeCount: store.vibesThisWeek()))
+    }
+
+    func getTimeline(in context: Context, completion: @escaping (Timeline<VibeEntry>) -> ()) {
+        let store = VibeStore.shared
+        let entry = VibeEntry(date: Date(), vibe: store.selectedVibe, vibeCount: store.vibesThisWeek())
+        let timeline = Timeline(entries: [entry], policy: .after(Date().addingTimeInterval(60*60)))
+        completion(timeline)
+    }
+}
+
+struct VibeWidgetEntryView : View {
+    var entry: Provider.Entry
+
+    var body: some View {
+        VStack {
+            if let vibe = entry.vibe {
+                Text("Your vibe: \(vibe.emoji) \(vibe.name)")
+                    .font(.headline)
+            } else {
+                Text("No vibe yet — pick one!")
+                    .font(.headline)
+            }
+            Text("You've picked \(entry.vibeCount) vibes this week.")
+                .font(.footnote)
+        }
+        .padding()
+        .widgetURL(URL(string: "vibeapp://"))
+    }
+}
+
+@main
+struct VibeWidget: Widget {
+    let kind: String = "VibeWidget"
+
+    var body: some WidgetConfiguration {
+        StaticConfiguration(kind: kind, provider: Provider()) { entry in
+            VibeWidgetEntryView(entry: entry)
+        }
+        .configurationDisplayName("Pick Your Vibe")
+        .description("Shows your current vibe and stats.")
+    }
+}


### PR DESCRIPTION
## Summary
- add simple SwiftUI vibe picker and widget
- track vibe history in `VibeStore` using App Groups
- show selected vibe and count in widget with deep link
- add basic celebration animation for every seventh pick
- update README with build notes
- ignore typical Xcode build artifacts

## Testing
- `swift --version`
- `swift build` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68413efe0fb8832a9783288a373866a7